### PR TITLE
added all moka tasks

### DIFF
--- a/lm_eval/tasks/moka/Code2Text_ICD10.yaml
+++ b/lm_eval/tasks/moka/Code2Text_ICD10.yaml
@@ -1,0 +1,41 @@
+tag: moka
+task: Code2Text_ICD10
+
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+ data_files: /path/to/ICD10-processed.json
+
+process_docs: !function utils.process_doc
+
+output_type: multiple_choice
+
+test_split: train
+
+doc_to_text: "You will be presented with an excerpt from a medical document accompanied by four numerical codes.
+Each code represents a possible medical classification for the provided text. 
+Your task is to select the code that best matches the text by entering only the number of the appropriate code as your response. 
+It is imperative that your response consists strictly of a single number between 1 and 4.
+Text: {{Code}}
+Code 1: {{A1Text}}
+Code 2: {{A2Text}}
+Code 3: {{A3Text}}
+Code 4: {{A4Text}}
+Insert the number of the correct code here:"
+
+doc_to_target: Correct
+
+doc_to_choice: ['1','2','3','4']
+
+process_results: !function utils.process_results            
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: weighted_error
+    aggregation: mean
+    higher_is_better: false
+
+
+

--- a/lm_eval/tasks/moka/Code2Text_ICD9CM.yaml
+++ b/lm_eval/tasks/moka/Code2Text_ICD9CM.yaml
@@ -1,0 +1,40 @@
+tag: moka
+task: Code2Text_ICD9CM
+
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+ data_files: /path/to/ICD9CM-processed.json
+
+process_docs: !function utils.process_doc
+
+output_type: multiple_choice
+
+test_split: train
+
+doc_to_text: "You will be presented with an excerpt from a medical document accompanied by four numerical codes.
+Each code represents a possible medical classification for the provided text. 
+Your task is to select the code that best matches the text by entering only the number of the appropriate code as your response. 
+It is imperative that your response consists strictly of a single number between 1 and 4.
+Text: {{Code}}
+Code 1: {{A1Text}}
+Code 2: {{A2Text}}
+Code 3: {{A3Text}}
+Code 4: {{A4Text}}
+Insert the number of the correct code here:"
+
+doc_to_target: Correct
+
+doc_to_choice: ['1','2','3','4']
+
+process_results: !function utils.process_results            
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: weighted_error
+    aggregation: mean
+    higher_is_better: false
+
+

--- a/lm_eval/tasks/moka/Code2Text_ICF.yaml
+++ b/lm_eval/tasks/moka/Code2Text_ICF.yaml
@@ -1,0 +1,41 @@
+tag: moka
+task: Code2Text_ICF
+
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+ data_files: /path/to/ICF-processed.json
+
+process_docs: !function utils.process_doc
+
+output_type: multiple_choice
+
+test_split: train
+
+doc_to_text: "You will be presented with an excerpt from a medical document accompanied by four numerical codes.
+Each code represents a possible medical classification for the provided text. 
+Your task is to select the code that best matches the text by entering only the number of the appropriate code as your response. 
+It is imperative that your response consists strictly of a single number between 1 and 4.
+Text: {{Code}}
+Code 1: {{A1Text}}
+Code 2: {{A2Text}}
+Code 3: {{A3Text}}
+Code 4: {{A4Text}}
+Insert the number of the correct code here:"
+
+doc_to_target: Correct
+
+doc_to_choice: ['1','2','3','4']
+
+process_results: !function utils.process_results            
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: weighted_error
+    aggregation: mean
+    higher_is_better: false
+
+
+

--- a/lm_eval/tasks/moka/README.md
+++ b/lm_eval/tasks/moka/README.md
@@ -1,0 +1,15 @@
+# Task-name
+MOKA
+
+### Paper
+
+Title: `MOKA - Medical Ontologies Knowledge Assessment:A CALAMITA Challenge`
+
+Abstract: ``
+``
+
+### Citation
+
+```
+
+```

--- a/lm_eval/tasks/moka/Text2Code_ICD10.yaml
+++ b/lm_eval/tasks/moka/Text2Code_ICD10.yaml
@@ -1,0 +1,43 @@
+tag: moka
+task: Text2Code_ICD10
+
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+ data_files: /path/to/ICD10-processed.json
+
+process_docs: !function utils.process_doc
+
+output_type: multiple_choice
+
+test_split: train
+
+doc_to_text: "You will be presented with an excerpt from a medical document accompanied by four numerical codes.
+Each code represents a possible medical classification for the provided text. 
+Your task is to select the code that best matches the text by entering only the number of the appropriate code as your response. 
+It is imperative that your response consists strictly of a single number between 1 and 4.
+Text: {{Text}}
+Code 1: {{A1Code}}
+Code 2: {{A2Code}}
+Code 3: {{A3Code}}
+Code 4: {{A4Code}}
+Insert the number of the correct code here:"
+
+doc_to_target: Correct
+
+doc_to_choice: ['1','2','3','4']
+
+process_results: !function utils.process_results            
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: weighted_error
+    aggregation: mean
+    higher_is_better: false
+  
+
+
+
+

--- a/lm_eval/tasks/moka/Text2Code_ICD9CM.yaml
+++ b/lm_eval/tasks/moka/Text2Code_ICD9CM.yaml
@@ -1,0 +1,40 @@
+tag: moka
+task: Text2Code_ICD9CM
+
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+ data_files: /path/to/ICD9CM-processed.json
+
+process_docs: !function utils.process_doc
+
+output_type: multiple_choice
+
+test_split: train
+
+doc_to_text: "You will be presented with an excerpt from a medical document accompanied by four numerical codes.
+Each code represents a possible medical classification for the provided text. 
+Your task is to select the code that best matches the text by entering only the number of the appropriate code as your response. 
+It is imperative that your response consists strictly of a single number between 1 and 4.
+Text: {{Text}}
+Code 1: {{A1Code}}
+Code 2: {{A2Code}}
+Code 3: {{A3Code}}
+Code 4: {{A4Code}}
+Insert the number of the correct code here:"
+
+doc_to_target: Correct
+
+doc_to_choice: ['1','2','3','4']
+
+process_results: !function utils.process_results            
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: weighted_error
+    aggregation: mean
+    higher_is_better: false
+
+

--- a/lm_eval/tasks/moka/Text2Code_ICF.yaml
+++ b/lm_eval/tasks/moka/Text2Code_ICF.yaml
@@ -1,0 +1,41 @@
+tag: moka
+task: Text2Code_ICF
+
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+ data_files: /path/to/ICF-processed.json
+
+process_docs: !function utils.process_doc
+
+output_type: multiple_choice
+
+test_split: train
+
+doc_to_text: "You will be presented with an excerpt from a medical document accompanied by four numerical codes.
+Each code represents a possible medical classification for the provided text. 
+Your task is to select the code that best matches the text by entering only the number of the appropriate code as your response. 
+It is imperative that your response consists strictly of a single number between 1 and 4.
+Text: {{Text}}
+Code 1: {{A1Code}}
+Code 2: {{A2Code}}
+Code 3: {{A3Code}}
+Code 4: {{A4Code}}
+Insert the number of the correct code here:"
+
+doc_to_target: Correct
+
+doc_to_choice: ['1','2','3','4']
+
+process_results: !function utils.process_results            
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: weighted_error
+    aggregation: mean
+    higher_is_better: false
+
+
+

--- a/lm_eval/tasks/moka/utils.py
+++ b/lm_eval/tasks/moka/utils.py
@@ -1,0 +1,60 @@
+from datasets import Dataset
+import datasets
+
+def process_doc(dataset: datasets.Dataset):
+    '''
+    This function allows the adaptation of a JSON dataset, changing some names and types of columns,
+    so that it is correctly processed during evaluation
+    '''
+
+    df = dataset.to_pandas()
+
+    df.columns = [col.replace('-', '') for col in df.columns]
+
+    columns_to_convert = ['Correct', 'Sibling', 'Close', 'Random']
+    df[columns_to_convert] = df[columns_to_convert].astype(str)
+
+    dataset = Dataset.from_pandas(df)
+    
+    return dataset
+
+
+
+def process_results(doc, predictions):
+    '''
+    This function takes as input the loglikelihood's associated with the multiple choice options
+    and allows the computation of the accuracy score and a further custom weighted error metric
+    '''
+
+    gold_label = int(doc['Correct'])
+
+    pred_label = 1 + max(enumerate(predictions), key=lambda x: x[1][0])[0]
+   
+    acc = compute_accuracy(gold_label, pred_label)
+    weighted_error = compute_weighted_error(doc, pred_label)
+    
+    
+    return {"weighted_error": weighted_error, "acc": acc}
+
+def compute_accuracy(gold_label, pred_label):
+    return int(gold_label == pred_label)
+
+def compute_weighted_error(doc, pred_label):
+    
+    # Define weights for each type of prediction
+    weights = {
+        'Correct': 0,   # No error
+        'Sibling': 1,   # Slight error
+        'Close': 2,     # More significant error
+        'Random': 3     # Severe error
+    }
+    for key, weight in weights.items():
+        if pred_label == int(doc[key]):
+            return weight
+    return max(weights.values())  # Assume maximum error if none match
+    
+
+
+
+
+


### PR DESCRIPTION
### Pull requests to add all **moka** tasks.
It's already tested on a GPU.

Please note:
This task is composed of 6 subtasks deriving from 3 datasets from the authors: 

- ICD9CM-processed.pqt
- ICD10-processed.pqt
- ICF-processed.pqt

These datasets have not been uploaded on Huggingface. So, to run their evaluation smoothly, I strongly recommend converting them to JSON format before putting them in a local folder. The `process_docs` function will then do the rest.

To Do:
Include paper elements (the abstract and citation) in the README file