### PR TITLE
BEEP, BLM-IT, MULTI-IT, TRACEIT, VERYFIT

### DIFF
--- a/lm_eval/tasks/VeryfIT/utils.py
+++ b/lm_eval/tasks/VeryfIT/utils.py
@@ -1,0 +1,12 @@
+def doc_to_text(doc) -> str:
+    statement = doc["statement"]
+    statement_date = doc["statement_date"]
+    return f"Il seguente statement nella data indicata era vero o falso? Rispondi solo 'Vero' o 'Falso'.\nStatement: {statement}\nData: {statement_date}"
+
+def doc_to_text_clarified(doc) -> str:
+    if doc["annotato"] and doc["statement_revised"] != "":
+      statement = doc["statement_revised"]
+    else:
+      statement = doc["statement"]
+    statement_date = doc["statement_date"]
+    return f"Il seguente statement nella data indicata era vero o falso? Rispondi solo 'Vero' o 'Falso'.\nStatement: {statement}\nData: {statement_date}"

--- a/lm_eval/tasks/VeryfIT/veryfIT.yaml
+++ b/lm_eval/tasks/VeryfIT/veryfIT.yaml
@@ -1,7 +1,7 @@
 group: veryfIT
 task:
   - veryfIT_small
-  - veryfIT_clarified
+  - veryfIT_enriched
   - veryfIT_full
 metadata:
   version: 1.0

--- a/lm_eval/tasks/VeryfIT/veryfIT.yaml
+++ b/lm_eval/tasks/VeryfIT/veryfIT.yaml
@@ -1,0 +1,7 @@
+group: veryfIT
+task:
+  - veryfIT_small
+  - veryfIT_clarified
+  - veryfIT_full
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/VeryfIT/veryfIT_enriched.yaml
+++ b/lm_eval/tasks/VeryfIT/veryfIT_enriched.yaml
@@ -1,0 +1,3 @@
+include: veryfIT_small.yaml
+task: veryfIT_enriched
+doc_to_text: !function utils.doc_to_text_clarified

--- a/lm_eval/tasks/VeryfIT/veryfIT_full.yaml
+++ b/lm_eval/tasks/VeryfIT/veryfIT_full.yaml
@@ -1,0 +1,22 @@
+tag:
+  - fact-checking
+  - factual knowledge
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+  data_files:
+    test: # path to full set
+task: veryfIT_full
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: ['Vero', 'Falso']
+doc_to_target: verdict
+training_split: null
+validation_split: null
+test_split: test
+output_type: multiple_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/VeryfIT/veryfIT_small.yaml
+++ b/lm_eval/tasks/VeryfIT/veryfIT_small.yaml
@@ -1,0 +1,22 @@
+tag:
+  - fact-checking
+  - factual knowledge
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+  data_files:
+    test: # path to small dataset
+task: veryfIT_small
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: ['Vero', 'Falso']
+doc_to_target: verdict
+training_split: null
+validation_split: null
+test_split: test
+output_type: multiple_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/beep/beep.yaml
+++ b/lm_eval/tasks/beep/beep.yaml
@@ -1,0 +1,21 @@
+tag:
+  - multiple choice
+  - driving quiz
+  - driving license
+dataset_path: 'Crisp-Unimib/BEEP_eval' # the name of the dataset on the HF Hub.
+dataset_name: null # the dataset configuration to use. Leave `null` if your dataset does not require a config to be passed. See https://huggingface.co/docs/datasets/load_hub#configurations for more info.
+dataset_kwargs: null # any extra keyword arguments that should be passed to the dataset constructor, e.g. `data_dir`.
+task: beep
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: ['A', 'B']
+doc_to_target: !function utils.doc_to_target
+training_split: null
+validation_split: null
+test_split: train
+output_type: multiple_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/beep/utils.py
+++ b/lm_eval/tasks/beep/utils.py
@@ -1,0 +1,12 @@
+def doc_to_text(doc) -> str:
+    question = doc['Question Text']
+    doc_to_text = f"Domanda: {question}\n"
+    doc_to_text += "Opzioni: 'A. Vero' , 'B. Falso'\nIstruzioni: Devi restituire solo la lettera corrispondente alla risposta esatta.\nFormato della risposta: 'lettera'\nRisposta:"
+
+    return doc_to_text
+
+def doc_to_target(doc) -> str:
+    if doc['Answer Type']:
+      return 'A'
+    else:
+      return 'B'

--- a/lm_eval/tasks/blm-IT/agr_tasks.yaml
+++ b/lm_eval/tasks/blm-IT/agr_tasks.yaml
@@ -1,0 +1,11 @@
+group: agr_tasks
+task:
+  - blm_agr1_0shots
+  - blm_agr2_0shots
+  - blm_agr1_1shots
+  - blm_agr2_1shots
+aggregate_metric_list:
+  - metric: f1
+    aggregation: mean
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/blm-IT/base.yaml
+++ b/lm_eval/tasks/blm-IT/base.yaml
@@ -1,0 +1,18 @@
+tag:
+  - Language Matrices
+  - Causative alternation
+dataset_path: json
+dataset_name: null
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: ["A", "B", "C", "D", "E", "F", "G", "H"]
+doc_to_target: Correct_option
+training_split: null
+validation_split: null
+test_split: test
+output_type: multiple_choice
+metric_list:
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/blm-IT/blm-it.yaml
+++ b/lm_eval/tasks/blm-IT/blm-it.yaml
@@ -1,0 +1,7 @@
+group: blm-IT
+task:
+  - agr_tasks
+  - od_tasks
+  - caus_tasks
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/blm-IT/blm_agr1_0shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_agr1_0shots.yaml
@@ -1,0 +1,8 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-II/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-II/test.json
+task: blm_agr1_0shots
+
+num_fewshot: 0

--- a/lm_eval/tasks/blm-IT/blm_agr1_1shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_agr1_1shots.yaml
@@ -1,0 +1,9 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-II/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-II/test.json
+task: blm_agr1_1shots
+
+fewshot_split: train
+num_fewshot: 1

--- a/lm_eval/tasks/blm-IT/blm_agr2_0shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_agr2_0shots.yaml
@@ -1,0 +1,8 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-III/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-III/test.json
+task: blm_agr2_0shots
+
+num_fewshot: 0

--- a/lm_eval/tasks/blm-IT/blm_agr2_1shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_agr2_1shots.yaml
@@ -1,0 +1,9 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-III/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-AgrIt_type-III/test.json
+task: blm_agr2_1shots
+
+fewshot_split: train
+num_fewshot: 1

--- a/lm_eval/tasks/blm-IT/blm_caus1_0shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_caus1_0shots.yaml
@@ -1,0 +1,7 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-II/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-II/test.json
+task: blm_caus1_0shots
+num_fewshot: 0

--- a/lm_eval/tasks/blm-IT/blm_caus1_1shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_caus1_1shots.yaml
@@ -1,0 +1,9 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-II/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-II/test.json
+task: blm_caus1_1shots
+
+fewshot_split: train
+num_fewshot: 1

--- a/lm_eval/tasks/blm-IT/blm_caus2_0shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_caus2_0shots.yaml
@@ -1,0 +1,8 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-III/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-III/test.json
+task: blm_caus2_0shots
+
+num_fewshot: 0

--- a/lm_eval/tasks/blm-IT/blm_caus2_1shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_caus2_1shots.yaml
@@ -1,0 +1,9 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-III/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-CausIt_type-III/test.json
+task: blm_caus2_1shots
+
+fewshot_split: train
+num_fewshot: 1

--- a/lm_eval/tasks/blm-IT/blm_od1_0shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_od1_0shots.yaml
@@ -1,0 +1,7 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-II/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-II/test.json
+task: blm_od1_0shots
+num_fewshot: 0

--- a/lm_eval/tasks/blm-IT/blm_od1_1shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_od1_1shots.yaml
@@ -1,0 +1,9 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-II/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-II/test.json
+task: blm_od1_1shots
+
+fewshot_split: train
+num_fewshot: 1

--- a/lm_eval/tasks/blm-IT/blm_od2_0shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_od2_0shots.yaml
@@ -1,0 +1,8 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-III/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-III/test.json
+task: blm_od2_0shots
+
+num_fewshot: 0

--- a/lm_eval/tasks/blm-IT/blm_od2_1shots.yaml
+++ b/lm_eval/tasks/blm-IT/blm_od2_1shots.yaml
@@ -1,0 +1,9 @@
+include: base.yaml
+dataset_kwargs:
+  data_files:
+    train: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-III/train.json
+    test: /home/jj/Downloads/BLM-It2/BLM-OdIt_type-III/test.json
+task: blm_od2_1shots
+
+fewshot_split: train
+num_fewshot: 1

--- a/lm_eval/tasks/blm-IT/caus_tasks.yaml
+++ b/lm_eval/tasks/blm-IT/caus_tasks.yaml
@@ -1,0 +1,11 @@
+group: caus_tasks
+task:
+  - blm_caus1_0shots
+  - blm_caus2_0shots
+  - blm_caus1_1shots
+  - blm_caus2_1shots
+aggregate_metric_list:
+  - metric: f1
+    aggregation: mean
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/blm-IT/od_tasks.yaml
+++ b/lm_eval/tasks/blm-IT/od_tasks.yaml
@@ -1,0 +1,11 @@
+group: od_tasks
+task:
+  - blm_od1_0shots
+  - blm_od2_0shots
+  - blm_od1_1shots
+  - blm_od2_1shots
+aggregate_metric_list:
+  - metric: f1
+    aggregation: mean
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/blm-IT/utils.py
+++ b/lm_eval/tasks/blm-IT/utils.py
@@ -1,0 +1,14 @@
+def doc_to_text(doc) -> str:
+  Context_concatenated= doc['Context_concatenated']
+  Answer_concatenated = doc['Answer_concatenated']
+  doc_to_text = f"Ti chiedo di risolvere un quesito. La lingua di questo quesito e' l'italiano."
+  doc_to_text += f"\nTi daro' una lista di frasi (numerate da 1 a 7) che chiameremo **Contesto**, e un insieme di frasi (identificate da una lettera) che chiameremo **Risposte**.."
+  doc_to_text += f"\nIl tuo compito e' di scegliere fra le **Risposte** la frase che potrebbe essere la frase seguente del **Contesto**."
+  doc_to_text += f"\n# FORMATO: Devi mettere **SOLO** la lettera che corrisponde alla risposta migliore. Non inserire altro testo, ne' prima ne' dopo."
+  doc_to_text += f"\n# DOMANDA"
+  doc_to_text += f"\n**Contesto**"
+  doc_to_text += f"\n{Context_concatenated}"
+  doc_to_text += f"\n**Risposte**"
+  doc_to_text += f"\n{Answer_concatenated}"
+  doc_to_text += f"\n**La tua scelta**\n"
+  return doc_to_text

--- a/lm_eval/tasks/multi-it/multi-IT.yaml
+++ b/lm_eval/tasks/multi-it/multi-IT.yaml
@@ -1,0 +1,6 @@
+group: Multi-IT
+task:
+  - multi-it-c
+  - multi-it-a
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/multi-it/multi-it-a.yaml
+++ b/lm_eval/tasks/multi-it/multi-it-a.yaml
@@ -1,0 +1,25 @@
+tag:
+  - knowledge
+  - general knowledge
+  - concorsi pubblici
+  - standardised tests
+  - job
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+  data_files:
+    test: /home/jj/Downloads/Multi-IT/Multi-IT-A/quiz.json
+task: multi-it-a
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: !function utils.doc_to_choice
+doc_to_target: answer
+training_split: null
+validation_split: null
+test_split: test
+output_type: multiple_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/multi-it/multi-it-c.yaml
+++ b/lm_eval/tasks/multi-it/multi-it-c.yaml
@@ -1,0 +1,25 @@
+tag:
+  - knowledge
+  - general knowledge
+  - concorsi pubblici
+  - standardised tests
+  - job
+dataset_path: json
+dataset_name: null
+dataset_kwargs:
+  data_files:
+    test: /home/jj/Downloads/Multi-IT/Multi-IT-C/quiz.json
+task: multi-it-c
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: !function utils.doc_to_choice
+doc_to_target: answer
+training_split: null
+validation_split: null
+test_split: test
+output_type: multiple_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/multi-it/utils.py
+++ b/lm_eval/tasks/multi-it/utils.py
@@ -1,0 +1,34 @@
+def doc_to_text(doc) -> str:
+    """
+    Converts a document to a formatted string.
+
+    Args:
+        doc (dict): A dictionary containing the document information.
+
+    Returns:
+        str: A formatted string containing the question and answer choices.
+    """
+    letters = ['A', 'B', 'C', 'D', 'E']
+    question = doc['question']
+    doc_to_text = f"Di seguito è riportata una domanda a scelta multipla e le possibili risposte. Scegli la lettera che meglio risponde alla domanda. Mantieni la tua risposta il più breve possibile; indica solo la lettera corrispondente alla tua risposta senza spiegazioni."
+    doc_to_text += f"\nDomanda: {question}"
+    doc_to_text += f"\nPossibili risposte:"
+
+    for i in range(len(doc["choices"])):
+      doc_to_text += f"\n{letters[i]}) {doc['choices'][i]}"
+    doc_to_text += "\nRisposta:"
+
+    return doc_to_text
+
+def doc_to_choice(doc) -> str:
+    """
+    Converts a document to a formatted string.
+
+    Args:
+        doc (dict): A dictionary containing the document information.
+
+    Returns:
+        str: A formatted string containing the question and answer choices.
+    """
+    letters = ['A', 'B', 'C', 'D', 'E']
+    return letters[:len(doc['choices'])]

--- a/lm_eval/tasks/traceIT/traceIT.yaml
+++ b/lm_eval/tasks/traceIT/traceIT.yaml
@@ -1,0 +1,25 @@
+tag:
+  - multiple choice
+  - correlation
+  - linguistics
+  - reading
+dataset_path: 'DominiqueBrunato/TRACE-it_CALAMITA' # the name of the dataset on the HF Hub.
+dataset_name: null # the dataset configuration to use. Leave `null` if your dataset does not require a config to be passed. See https://huggingface.co/docs/datasets/load_hub#configurations for more info.
+dataset_kwargs: null # any extra keyword arguments that should be passed to the dataset constructor, e.g. `data_dir`.
+task: traceIT
+doc_to_text: !function utils.doc_to_text
+doc_to_choice: ['sì', 'no']
+doc_to_target: Gold
+training_split: null
+validation_split: null
+test_split: train
+output_type: multiple_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: f1
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/traceIT/utils.py
+++ b/lm_eval/tasks/traceIT/utils.py
@@ -1,0 +1,9 @@
+def doc_to_text(doc) -> str:
+    SENTENCE1 = doc['Sentence1']
+    SENTENCE2 = doc['Sentence2']
+    doc_to_text = f"Data questa coppia di frasi, valuta se la prima frase implica la seconda. Rispondi solo 'sì' o 'no'."
+    doc_to_text = f"\nFrase 1: {SENTENCE1}"
+    doc_to_text = f"\nFrase 2: {SENTENCE2}"
+    doc_to_text += "\nRisposta:"
+
+    return doc_to_text


### PR DESCRIPTION
- BEEP
- BLM-IT split in 3 subgroups
   - agr_tasks: four tasks:
      - first dataset, zero shot
      - first dataset, one shot
      - second dataset, zero shot
      - second dataset, one shot
   - caus tasks: same
   - od tasks: same
- Multi-IT split in 2 subtasks based on 2 different datasets:
   - Multi-it-a
   - Multi-it-c
- TraceIT
- VeryfIT split in 3 subtasks:
   - VeryfIT_full
   - VeryfIT_small
   - VeryfIT_enriched

Important: 
1. Dataset for Multi-it, BLM-it and VeryfIT are not public
2. BLM dataset needed to be altered as HF conversion was not working. ask me for the updated version